### PR TITLE
build lib path fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /work/RPiPlay
 
 # Copy the libdns_sd library
 RUN mkdir build
-RUN cp /usr/lib/arm-linux-gnueabihf/libdns_sd.so.1 ./build/
+RUN cp /usr/lib/arm-linux-gnueabi/libdns_sd.so.1 ./build/
 
 # Alter the cmake file to use the libdns_sd library locally
 RUN printf "\nadd_library(dns_sd SHARED IMPORTED GLOBAL)\nset_target_properties(dns_sd PROPERTIES IMPORTED_LOCATION \"./libdns_sd.so.1\")\n" >>./lib/CMakeLists.txt


### PR DESCRIPTION
I tried to build the rpiplay on my libreelec box, but it faild during the installation. The reason was wrong path to the system libs. I overwrote it in the Dockerfile and it worked again.